### PR TITLE
use bcrypt password hashing and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,22 @@ A nio module providing basic security authentication
 
 [security]
 
-user in the system, where each entry is defined as "[Username]": {"password": "[base64 encoded password]"} ("User": {"password": "VXNlcg=="})
+user in the system, where each entry is defined as: 
+```
+"[Username]": {"password": "[base64 encoded password]"} ("User": {"password": "VXNlcg=="})
+```
+or
+```
+"[Username]": {"password": "[bcypt hashed password]"} ("User": {"password": "$2b$12$pgfW7h9YEAkm5HafKuvT/uyChSMr9FgEFDxmM9uTZOSMJSvFUmiOW" })
+```
 - users=etc/users.json
 
-user permissions in the system, where each entry is defined as [Username]: [list of permissions] ("Admin": ["*"])
+user permissions in the system, where each entry is defined as:
+```
+[Username]: [dictionary of permissions] ("Admin": {".*": "rwx"})
+```
 - permissions=etc/permissions.json
 
 ## Dependencies
 
-- None
+- bcrypt

--- a/module.py
+++ b/module.py
@@ -15,8 +15,9 @@ class BasicSecurityModule(SecurityModule):
         self.proxy_authenticator_class(Authenticator)
         self.proxy_authorizer_class(Authorizer)
 
-        Authenticator._configure_users(context.users)
-        Authenticator._configure_unhashed(context.allow_unhashed_passwords)
+        Authenticator.\
+            _configure(users=context.users, 
+                       allow_unhashed=context.allow_unhashed_passwords)
         Authorizer._configure_permissions(context.permissions)
 
     def _prepare_common_context(self):

--- a/module.py
+++ b/module.py
@@ -16,6 +16,7 @@ class BasicSecurityModule(SecurityModule):
         self.proxy_authorizer_class(Authorizer)
 
         Authenticator._configure_users(context.users)
+        Authenticator._configure_unhashed(context.allow_unhashed_passwords)
         Authorizer._configure_permissions(context.permissions)
 
     def _prepare_common_context(self):
@@ -26,6 +27,9 @@ class BasicSecurityModule(SecurityModule):
         context.permissions = \
             Settings.getdict('security',
                              'permissions', fallback="etc/permissions.json")
+        context.allow_unhashed_passwords = \
+            Settings.getboolean('security',
+                                'allow_unhashed_passwords', fallback=True)
 
         return context
 

--- a/tests/test_basic_authentication.py
+++ b/tests/test_basic_authentication.py
@@ -30,6 +30,7 @@ class TestBasicAuthentication(NIOTestCase):
                 "HashName": {
                     "password": hashpw(b'HashPass', gensalt()).decode()}
             }
+            context.allow_unhashed_passwords = True
             context.permissions = {}
             return context
         else:

--- a/tests/test_basic_authentication.py
+++ b/tests/test_basic_authentication.py
@@ -1,4 +1,6 @@
 from unittest.mock import MagicMock
+from bcrypt import hashpw, gensalt
+
 from nio.modules.context import ModuleContext
 from ..base64 import base64_encode
 from nio.testing.test_case import NIOTestCase
@@ -24,7 +26,9 @@ class TestBasicAuthentication(NIOTestCase):
         if module_name == 'security':
             context = ModuleContext()
             context.users = {
-                "TestName": {"password": base64_encode("TestPass")}
+                "TestName": {"password": base64_encode("TestPass")},
+                "HashName": {
+                    "password": hashpw(b'HashPass', gensalt()).decode()}
             }
             context.permissions = {}
             return context
@@ -44,6 +48,22 @@ class TestBasicAuthentication(NIOTestCase):
         request = MagicMock(spec=Request)
         request.get_header.return_value = "Basic {}".format(
             base64_encode("TestName:WrongPass"))
+        with self.assertRaises(Unauthorized):
+            Authenticator.authenticate(request=request)
+
+    def test_hashed_basic_auth(self):
+        """ Test basic auth with hashed password """
+        request = MagicMock(spec=Request)
+        request.get_header.return_value = "Basic {}".format(
+            base64_encode("HashName:HashPass"))
+        user = Authenticator.authenticate(request=request)
+        self.assertEqual('HashName', user.name)
+
+    def test_hashed_basic_auth_invalid_pass(self):
+        """ Test basic auth with wrong hashed password """
+        request = MagicMock(spec=Request)
+        request.get_header.return_value = "Basic {}".format(
+            base64_encode("HashName:WrongPass"))
         with self.assertRaises(Unauthorized):
             Authenticator.authenticate(request=request)
 

--- a/tests/test_basic_authentication.py
+++ b/tests/test_basic_authentication.py
@@ -68,6 +68,15 @@ class TestBasicAuthentication(NIOTestCase):
         with self.assertRaises(Unauthorized):
             Authenticator.authenticate(request=request)
 
+    def test_unhashed_with_wrong_context(self):
+        Authenticator._configure_unhashed(False)
+
+        request = MagicMock(spec=Request)
+        request.get_header.return_value = "Basic {}".format(
+            base64_encode("TestName:TestPass"))
+        with self.assertRaises(Unauthorized):
+            Authenticator.authenticate(request=request)
+
     def test_header_missing(self):
         """ Test missing authorization header.
 

--- a/tests/test_basic_authentication.py
+++ b/tests/test_basic_authentication.py
@@ -69,7 +69,10 @@ class TestBasicAuthentication(NIOTestCase):
             Authenticator.authenticate(request=request)
 
     def test_unhashed_with_wrong_context(self):
-        Authenticator._configure_unhashed(False)
+        Authenticator._configure(users={"TestName": {
+                                            "password": 
+                                                base64_encode("TestPass")}},
+                                 allow_unhashed=False)
 
         request = MagicMock(spec=Request)
         request.get_header.return_value = "Basic {}".format(

--- a/tests/test_basic_authorization.py
+++ b/tests/test_basic_authorization.py
@@ -22,6 +22,7 @@ class TestBasicAuthorization(NIOTestCase):
         if module_name == 'security':
             context = ModuleContext()
             context.users = {}
+            context.allow_unhashed_passwords = True
             context.permissions = {
                 "user1": {"services": "r", "blocks": "r"},
                 "user3": {}

--- a/tests/test_first_gen_security_compatibility.py
+++ b/tests/test_first_gen_security_compatibility.py
@@ -22,6 +22,7 @@ class TestFirstGenPermissions(NIOTestCase):
         if module_name == 'security':
             context = ModuleContext()
             context.users = {}
+            context.allow_unhashed_passwords = True
             context.permissions = {
                 "user1": ['*']
             }


### PR DESCRIPTION
With this, the CLI will be storing passwords using a bcrypt hash. This module will take a password from basic auth and compare it with the stored, hashed password using available bcrypt methods. Unit tests are provided and a test password can be created on a project in python doing
```
import bcrypt
bcrypt.hashpw(b'Admin', bcrypt.gensalt())
```
And replacing the password in etc/users.json for the Admin user